### PR TITLE
Remove configuration of root logger

### DIFF
--- a/edge_mender/edge_mender.py
+++ b/edge_mender/edge_mender.py
@@ -15,13 +15,11 @@ from edge_mender.non_manifold_edges import (
 )
 from edge_mender.non_manifold_vertices import repair_vertices
 
-logging.basicConfig(format="%(message)s")
-
 
 class EdgeMender:
     """The class for repairing non-manifold edges in voxel boundary meshes."""
 
-    def __init__(self, mesh: trimesh.Trimesh, *, debug: bool = False) -> None:
+    def __init__(self, mesh: trimesh.Trimesh) -> None:
         self.mesh = mesh
         self._face_normals: NDArray[np.float64] = np.empty((0, 3), dtype=np.float64)
         """Return the unit normal vector for each face.
@@ -34,7 +32,6 @@ class EdgeMender:
         Normal vectors of each face
         """
         self.logger = logging.getLogger(__name__)
-        self.logger.setLevel(logging.DEBUG if debug else logging.WARNING)
 
     def validate(self, *, spacing: tuple[float, float, float]) -> None:
         """Validate that the mesh is a valid voxel boundary mesh before repair.

--- a/tests/test_edge_mender_unit.py
+++ b/tests/test_edge_mender_unit.py
@@ -13,9 +13,7 @@ from edge_mender.non_manifold_edges import get_faces_at_edge, get_faces_at_verte
 def test_edge_mender_init() -> None:
     """Test that the EdgeMender class can be initialized."""
     mesh = trimesh.creation.box()
-
     EdgeMender(mesh)
-    EdgeMender(mesh, debug=True)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR closes #11 by removing the manipulation of the root logger. This was breaking logger configurations on consumers of this library. Instead, no configuration of the logger is done and this is left to the user.

This consequently made the `debug` flag null, so it has been removed.

To replicate behavior after this PR, simply add the following line to your code before using `EdgeMender`:

```py
logging.basicConfig(format="%(message)s", level=logging.DEBUG)
```

To configure the logger for edge-mender properly scoped, you can use something like:

```py
logger = logging.getLogger("edge_mender")
logger.setLevel(logging.DEBUG)
logger.addHandler(logging.StreamHandler())
```